### PR TITLE
clickNavigate option didn't work

### DIFF
--- a/dist/jquery.imagemapster.js
+++ b/dist/jquery.imagemapster.js
@@ -1339,7 +1339,9 @@ A jQuery plugin to enhance image maps.
             if (!$.mapster.hasCanvas) {
                 this.blur();
             }
-             e.preventDefault();
+            if(opts.clickNavigate == false) {
+               e.preventDefault();
+            }
         };
 
         this.mouseover = function (e) {


### PR DESCRIPTION
Hi jamietre,

I just fixed a problem I had when trying to keep my image maps clickable. The opton "clickNavigate" didn't stop the script from preventing link click. 

This is the first time I try to contribute to something on github, so forgive me if I did something wrong.

Great script by the way!
