### PR TITLE
Checking a couple vars for truthiness.

### DIFF
--- a/src/graphics.js
+++ b/src/graphics.js
@@ -306,7 +306,9 @@
         },
         clearHighlight: function () {
             var c = this.map_data.overlay_canvas;
-            c.getContext('2d').clearRect(0, 0, c.width, c.height);
+            if (c) {
+               c.getContext('2d').clearRect(0, 0, c.width, c.height);
+            }
         },
         // Draw all items from selected_list to a new canvas, then swap with the old one. This is used to delete items when using canvases.
         refreshSelections: function () {
@@ -314,14 +316,16 @@
             // draw new base canvas, then swap with the old one to avoid flickering
             canvas_temp = map_data.base_canvas;
 
-            map_data.base_canvas = this.createVisibleCanvas(map_data);
-            $(map_data.base_canvas).hide();
-            $(canvas_temp).before(map_data.base_canvas);
+            if (canvas_temp) {
+                map_data.base_canvas = this.createVisibleCanvas(map_data);
+                $(map_data.base_canvas).hide();
+                $(canvas_temp).before(map_data.base_canvas);
 
-            map_data.redrawSelections();
+                map_data.redrawSelections();
 
-            $(map_data.base_canvas).show();
-            $(canvas_temp).remove();
+                $(map_data.base_canvas).show();
+                $(canvas_temp).remove();
+            }
         }
     };
 


### PR DESCRIPTION
I am using ImageMapster with angular. When the two variables
I have corrected inside the refreshSelections and clearHighlight
functions are not set, console errors are generated.

Exact situation is me calling:
$('#mapster').mapster('set', false, regionList.join());
where regionList.join() returns an empty string in one case. When
there _are_ no previous selections, errors occur when the two vars
I corrected are attempted to be used while they are actually null.

I am guessing Mapster actually has safeguards against reaching this
code at a higher level when things are empty, but I'm using it only
as a simple highlight-storage area and tracking all state inside angular,
so probably that code is unable to kick in.
