### PR TITLE
split is undefined bug

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -122,6 +122,8 @@
             },
             // clean split: no padding or empty elements
             split: function (text,cb) {
+                var nativeSplit = String.prototype.split;
+                var i,el, arr = nativeSplit.call(text,',');
                 var i,el, arr = text.split(',');
                 for (i = 0; i < arr.length; i++) {
                     el = $.trim(arr[i]);


### PR DESCRIPTION
When trying to call set from within onConfigured, the text.split reference within the clean split function comes back as undefined.

I've wired in a direct reference to the native split function as I was uncertain why it wasn't detecting the reference.
