### PR TITLE
fix: ensure initialization completes on subsequent attempts

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -31,6 +31,7 @@
         <li><a href="boundlist.html">Bound List</a></li>
         <li><a href="skeleton.html">Skeleton Joints</a></li>
         <li><a href="frog.html">Frog Menu</a></li>
+        <li><a href="multipleinit.html">Multiple Initialization</a></li>
       </ul>
     </div>
   </body>

--- a/examples/multipleinit.html
+++ b/examples/multipleinit.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Multiple Initialization Test</title>
+
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/es6-promise/dist/es6-promise.auto.min.js"
+    ></script>
+
+    <script type="text/javascript" src="redist/jquery.3.7.1.min.js"></script>
+    <script
+      type="text/javascript"
+      src="../dist/jquery.imagemapster.js"
+    ></script>
+
+    <!-- <script type="text/javascript" src="redist/zepto.1.2.0.min.js"></script>
+    <script
+      type="text/javascript"
+      src="../dist/jquery.imagemapster.zepto.js"
+    ></script> -->
+
+    <link rel="stylesheet" href="stylesheets/base.css" />
+    <script>
+      $(function () {
+        'use strict';
+
+        var $frogImg = $('#frog-img'),
+          $beatlesImg = $('#beatles-img'),
+          frogCounter = 0,
+          beatlesCounter = 0,
+          frogOpts = {
+            mapKey: 'data-name',
+            onConfigured: function () {
+              $('#frogOnConfigured').text(++frogCounter);
+            }
+          },
+          beatlesOpts = {
+            mapKey: 'data-name',
+            onConfigured: function () {
+              $('#beatlesOnConfigured').text(++beatlesCounter);
+            }
+          };
+
+        $frogImg.mapster(frogOpts);
+        $frogImg.mapster(frogOpts);
+
+        $beatlesImg.mapster(beatlesOpts);
+        $beatlesImg.mapster('unbind');
+        $beatlesImg.mapster(beatlesOpts);
+      });
+    </script>
+  </head>
+
+  <body>
+    <div class="navmenu">
+      Return to <a href="index.html">Main Menu</a>
+      <hr />
+    </div>
+    <h2>Multiple Initialization Test</h2>
+    <p>
+      Test 'initialize' to ensure mapster is properly initialized when multiple
+      calls to initialize are made.
+    </p>
+    <p>The behavior should be:</p>
+    <ul>
+      <li>When hovering over a hotspot on either image, it should highlight</li>
+      <li>onConfigured count should be two (2) for each image map</li>
+    </ul>
+
+    <h3>Frog</h3>
+    <p>Calls mapster multiple times in succession</p>
+    <p>Frog onConfigured called: <span id="frogOnConfigured">0</span> times</p>
+    <div>
+      <img id="frog-img" src="images/frog_map.jpg" usemap="#frog-map" />
+
+      <map name="frog-map">
+        <area
+          shape="rect"
+          data-name="menu1hot"
+          coords="10,10,120,330"
+          href="#"
+        />
+        <area shape="rect" data-name="menu1" coords="10,340,110,390" href="#" />
+        <area
+          shape="rect"
+          data-name="menu2hot"
+          coords="120,10,230,330"
+          href="#"
+        />
+        <area
+          shape="rect"
+          data-name="menu2"
+          coords="120,340,220,390"
+          href="#"
+        />
+        <area
+          shape="rect"
+          data-name="menu3hot"
+          coords="230,10,340,330"
+          href="#"
+        />
+        <area
+          shape="rect"
+          data-name="menu3"
+          coords="230,340,330,390"
+          href="#"
+        />
+        <area
+          shape="rect"
+          data-name="menu4hot"
+          coords="340,10,450,330"
+          href="#"
+        />
+        <area
+          shape="rect"
+          data-name="menu4"
+          coords="340,340,440,390"
+          href="#"
+        />
+      </map>
+    </div>
+
+    <h3>Beatles</h3>
+    <p>Calls mapster, then unbind, then mapster again in succession</p>
+    <p>
+      Beatles onConfigured called: <span id="beatlesOnConfigured">0</span> times
+    </p>
+    <div>
+      <img
+        id="beatles-img"
+        src="images/beatles_basic.jpg"
+        style="width: 400px; height: 240px"
+        usemap="#beatles-map"
+      />
+
+      <map name="beatles-map">
+        <area
+          id="paul"
+          shape="rect"
+          data-name="paul,beatles"
+          coords="36,46,121,131"
+          href="#"
+        />
+        <area
+          id="ringo"
+          shape="rect"
+          data-name="ringo,beatles"
+          coords="113,76,198,161"
+          href="#"
+        />
+        <area
+          id="john"
+          shape="rect"
+          data-name="john,beatles"
+          coords="192,50,277,135"
+          href="#"
+        />
+        <area
+          id="george"
+          shape="rect"
+          data-name="george,beatles"
+          coords="262,60,347,145"
+          href="#"
+        />
+      </map>
+    </div>
+  </body>
+</html>

--- a/src/core.js
+++ b/src/core.js
@@ -1023,8 +1023,11 @@
         if (md) {
           me.unbind.apply(img);
           if (!md.complete) {
-            // will be queued
-            return true;
+            // in most situations, queueCommand should return true since we just queued unbind, however
+            // if not successfully queued, nothing remains in-process so we can continue
+            if (m.queueCommand(md, img, 'bind', [options])) {
+              return true;
+            }
           }
           md = null;
         }

--- a/tests/events.tests.js
+++ b/tests/events.tests.js
@@ -4,6 +4,74 @@ this.tests = this.tests || [];
 
 this.tests.push(
   iqtest
+    .create('initialize', 'multiple initialization')
+    .add('is initialized when multiple initializations', function (a) {
+      'use strict';
+
+      var me = this,
+        getPromise = function (name) {
+          return me.promises(name);
+        };
+
+      image.mapster(
+        $.extend(map_options, {
+          onConfigured: getPromise('configured').resolve
+        })
+      );
+
+      image.mapster(
+        $.extend(map_options, {
+          onConfigured: getPromise('configured2').resolve
+        })
+      );
+
+      getPromise('configured').then(function () {
+        getPromise('configured2').then(function () {
+          getPromise('finished').resolve();
+        });
+      });
+
+      a.resolves(getPromise('finished'), 'Configured was called 2 times');
+    })
+);
+
+this.tests.push(
+  iqtest
+    .create('initialize_unbind', 'multiple initialization with unbind')
+    .add('is initialized when init, unbind, init', function (a) {
+      'use strict';
+
+      var me = this,
+        getPromise = function (name) {
+          return me.promises(name);
+        };
+
+      image.mapster(
+        $.extend(map_options, {
+          onConfigured: getPromise('configured').resolve
+        })
+      );
+
+      image.mapster('unbind');
+
+      image.mapster(
+        $.extend(map_options, {
+          onConfigured: getPromise('configured2').resolve
+        })
+      );
+
+      getPromise('configured').then(function () {
+        getPromise('configured2').then(function () {
+          getPromise('finished').resolve();
+        });
+      });
+
+      a.resolves(getPromise('finished'), 'Configured was called 2 times');
+    })
+);
+
+this.tests.push(
+  iqtest
     .create('events', 'tests for imagemapster events')
     .add('Mouse Events', function (a) {
       'use strict';


### PR DESCRIPTION
# IMPORTANT

## What is this change for?

- [ ] Feature / enhancement - _Any change should be discussed in the associated Issue before proceeding. Failure to do so may result in the rejection of the pull request._
- [X] Bug
- [ ] Docs
- [ ] Tests

## Description (required)

The underlying issue is actually a regression from https://github.com/jamietre/ImageMapster/commit/0aca845be6d891fa3b8c297eacd16921248d65dd way back in October 2011.  In that commit, there was an change in approach to how deferred methods were executed.  Prior to the commit, when the situation arose were initialization was called but something else was "in-flight", `bind` (the equivalent of initialization) was added to the command processing queue.  However, in the change, [Lines 2165 thru 2172](https://github.com/jamietre/ImageMapster/blob/0aca845be6d891fa3b8c297eacd16921248d65dd/jquery.imagemapster.js#L2169), `img.bind` was put in its place which would actually call the [jquery.bind](https://api.jquery.com/bind/) method (aka. [jquery.on](https://api.jquery.com/on/)) to register an event listener.  The changes in this commit are the root cause of why this bug currently exists.

Since the above commit, the code was calling `jquery.bind` with no parameters which actually does nothing and even with parameters, would not have been an equivalent replacement in functionality to the previous `queue_command` that was called.

In https://github.com/jamietre/ImageMapster/commit/48125a694e8a973c7b741925f6dfb4867eebcd15, the [img.unbind](https://github.com/jamietre/ImageMapster/blob/48125a694e8a973c7b741925f6dfb4867eebcd15/jquery.imagemapster.js#L2510) was fixed to properly queue an `unbind` command, however the [img.bind](https://github.com/jamietre/ImageMapster/blob/48125a694e8a973c7b741925f6dfb4867eebcd15/jquery.imagemapster.js#L2513) was not updated/fixed.

In [this commit](https://github.com/jamietre/ImageMapster/commit/9e49e48ef8a0911d81a04398aab54a00e7c28b68#diff-8ab41fe13597e1554b5d6b4c227b5f123ff2d6726a7f3688a8b8d1224fe1d4f3R996), `bind` was changed to `on` since `bind` was deprecated in jQuery 3.

Finally, in [this commit](https://github.com/jamietre/ImageMapster/commit/889599347143b39b37d67995772463b37600eb75#diff-8ab41fe13597e1554b5d6b4c227b5f123ff2d6726a7f3688a8b8d1224fe1d4f3L1026), `on` was removed entirely since it does not do anything to begin with (see above).

In short, the change made in https://github.com/jamietre/ImageMapster/commit/0aca845be6d891fa3b8c297eacd16921248d65dd was incorrect and it should have queued a `bind/initialization` when map data is already present.  This ensures that the unbind called just prior completes fully before mapster is reinitialized.

This PR corrects the issue and ensures mapster is successfully initialized even on multiple initialization calls.

## Test plan (required)

- Tests were added to [events suite](https://github.com/jamietre/ImageMapster/compare/fix/issue-427?expand=1#diff-e942f95e3940032d4a25f697bc957d6ce8603d290a7669d8f59dc9f49f33895bR5)
- [Multiple Initialization](https://github.com/jamietre/ImageMapster/compare/fix/issue-427?expand=1#diff-a11faa5810ac713931e63304028150455c6e34d4aef559c6ab0b6c7219153ffaR34) test page was added to examples

## Closing issues

Closes #427